### PR TITLE
🔒 fix: XSS in JSON to HTML Table and related tools

### DIFF
--- a/src/pages/json/excel-to-json.astro
+++ b/src/pages/json/excel-to-json.astro
@@ -112,6 +112,15 @@ const useCases = [
       box.classList.remove('hidden');
     }
 
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     document.getElementById('fileInput').addEventListener('change', (e) => {
       const file = e.target.files[0];
       if (!file) return;
@@ -122,7 +131,7 @@ const useCases = [
           workbook = XLSX.read(evt.target.result, { type: 'binary' });
           const sheetSelect = document.getElementById('sheetSelect');
           sheetSelect.innerHTML = workbook.SheetNames.map(name => 
-            `<option value="${name}">${name}</option>`
+            `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`
           ).join('');
           
           if (workbook.SheetNames.length > 1) {

--- a/src/pages/json/json-to-excel.astro
+++ b/src/pages/json/json-to-excel.astro
@@ -105,6 +105,15 @@ const useCases = [
       box.classList.remove('hidden');
     }
 
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     function showPreview(data) {
       if (!Array.isArray(data) || data.length === 0) return;
       
@@ -112,14 +121,14 @@ const useCases = [
       const previewData = data.slice(0, 5);
       
       let html = '<thead class="bg-slate-100"><tr>';
-      keys.forEach(k => html += `<th class="px-3 py-2 text-left border-b border-slate-200">${k}</th>`);
+      keys.forEach(k => html += `<th class="px-3 py-2 text-left border-b border-slate-200">${escapeHtml(k)}</th>`);
       html += '</tr></thead><tbody>';
       
       previewData.forEach(row => {
         html += '<tr>';
         keys.forEach(k => {
           const val = row[k] !== undefined ? (typeof row[k] === 'object' ? JSON.stringify(row[k]) : row[k]) : '';
-          html += `<td class="px-3 py-2 border-b border-slate-100">${val}</td>`;
+          html += `<td class="px-3 py-2 border-b border-slate-100">${escapeHtml(val)}</td>`;
         });
         html += '</tr>';
       });

--- a/src/pages/json/json-to-html.astro
+++ b/src/pages/json/json-to-html.astro
@@ -134,7 +134,8 @@ const useCases = [
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
     }
 
     function jsonToHtmlTable(data, style, includeHeader) {

--- a/src/pages/json/json-to-table.astro
+++ b/src/pages/json/json-to-table.astro
@@ -140,6 +140,15 @@ const useCases = [
       box.classList.remove('hidden');
     }
 
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     function renderTable(data, keys) {
       const thead = document.getElementById('tableHead');
       const tbody = document.getElementById('tableBody');
@@ -148,7 +157,7 @@ const useCases = [
       let headerHtml = '<tr>';
       keys.forEach(key => {
         const sortClass = sortColumn === key ? (sortDirection === 'asc' ? 'sorted-asc' : 'sorted-desc') : '';
-        headerHtml += `<th class="${sortClass}" data-key="${key}">${key}<span class="sort-icon"></span></th>`;
+        headerHtml += `<th class="${sortClass}" data-key="${escapeHtml(key)}">${escapeHtml(key)}<span class="sort-icon"></span></th>`;
       });
       headerHtml += '</tr>';
       thead.innerHTML = headerHtml;
@@ -159,7 +168,7 @@ const useCases = [
         bodyHtml += '<tr>';
         keys.forEach(key => {
           const val = row[key] !== undefined ? (typeof row[key] === 'object' ? JSON.stringify(row[key]) : row[key]) : '';
-          bodyHtml += `<td>${val}</td>`;
+          bodyHtml += `<td>${escapeHtml(val)}</td>`;
         });
         bodyHtml += '</tr>';
       });

--- a/src/pages/json/table-to-json.astro
+++ b/src/pages/json/table-to-json.astro
@@ -182,6 +182,15 @@ const useCases = [
       box.classList.remove('hidden');
     }
 
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     function detectDelimiter(text) {
       const firstLine = text.split('\n')[0];
       const tabCount = (firstLine.match(/\t/g) || []).length;
@@ -231,14 +240,14 @@ const useCases = [
       const previewRows = rows.slice(0, 6);
       let html = '<thead><tr>';
       previewRows[0].forEach((cell, i) => {
-        html += `<th>${cell || `Column ${i+1}`}</th>`;
+        html += `<th>${escapeHtml(cell || `Column ${i+1}`)}</th>`;
       });
       html += '</tr></thead><tbody>';
       
       for (let i = 1; i < previewRows.length; i++) {
         html += '<tr>';
         previewRows[i].forEach(cell => {
-          html += `<td>${cell}</td>`;
+          html += `<td>${escapeHtml(cell)}</td>`;
         });
         html += '</tr>';
       }


### PR DESCRIPTION
This PR fixes a Cross-Site Scripting (XSS) vulnerability in the JSON to HTML Table converter and several related tools.

🎯 **What:** The vulnerability allowed unescaped JSON data to be rendered directly into the DOM using `innerHTML`, potentially executing malicious scripts.

⚠️ **Risk:** Attackers could craft malicious JSON input that, when processed by the tool, executes arbitrary JavaScript in the user's browser context. This could lead to session hijacking, data theft, or defacement.

🛡️ **Solution:**
- Enhanced the `escapeHtml` helper function to include single quotes (`'`) for more robust sanitization.
- Ensured all dynamic data (keys and values) from JSON/table inputs are passed through `escapeHtml` before being injected into HTML strings used for `innerHTML` updates.
- Extended these security fixes to other similar tools identified during the investigation:
    - JSON to Table
    - Table to JSON
    - JSON to Excel
    - Excel to JSON

No functionality was broken, and the tools now securely handle potentially malicious HTML characters in inputs.

---
*PR created automatically by Jules for task [6051092281357818947](https://jules.google.com/task/6051092281357818947) started by @ragsav*