### PR TITLE
🧹 [Code Health] Flatten deeply nested control structure in xml-to-json

### DIFF
--- a/src/pages/json/xml-to-json.astro
+++ b/src/pages/json/xml-to-json.astro
@@ -118,6 +118,17 @@ const useCases = [
         throw new Error('Invalid XML: ' + errorNode.textContent.split('\n')[0]);
       }
 
+      function appendNodeValue(obj, key, value) {
+        if (!obj[key]) {
+          obj[key] = value;
+          return;
+        }
+        if (!Array.isArray(obj[key])) {
+          obj[key] = [obj[key]];
+        }
+        obj[key].push(value);
+      }
+
       function parseNode(node) {
         const obj = {};
 
@@ -139,14 +150,7 @@ const useCases = [
             const childName = child.nodeName;
             const childValue = parseNode(child);
 
-            if (obj[childName]) {
-              if (!Array.isArray(obj[childName])) {
-                obj[childName] = [obj[childName]];
-              }
-              obj[childName].push(childValue);
-            } else {
-              obj[childName] = childValue;
-            }
+            appendNodeValue(obj, childName, childValue);
           } else if (child.nodeType === Node.TEXT_NODE) {
             const text = child.textContent.trim();
             if (text) textContent += text;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `xmlToJson` function inside `src/pages/json/xml-to-json.astro` contained a deeply nested `if/else` control structure at lines 142-149 inside the `parseNode` function. The control flow handled appending child node values to a parent object, checking if the key existed and whether it needed to be wrapped in an array.

💡 **Why:** How this improves maintainability
Flattening this deeply nested control structure by extracting it into a helper function `appendNodeValue` significantly improves readability. It isolates the array manipulation logic, reducing the cognitive load required to understand the loop iteration over child nodes. Using an early return in the helper function reduces the level of nesting.

✅ **Verification:** How you confirmed the change is safe
Ran `npm run build` which compiled successfully, confirming that the code refactoring did not introduce any syntax errors or structural regressions. The extracted helper function maintains the exact logic by mutating the object reference. Requested code review which approved the change as a correct and safe improvement.

✨ **Result:** The improvement achieved
The `parseNode` function is now cleaner and easier to follow, with the complex array checking logic delegated to a dedicated, easily understandable helper function `appendNodeValue`.

---
*PR created automatically by Jules for task [4000849216414298960](https://jules.google.com/task/4000849216414298960) started by @ragsav*