### PR TITLE
🧹 [code health] Remove unused CONSTANT import in ToolLayout.astro

### DIFF
--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -6,7 +6,6 @@
  * Cluster-specific layouts extend this with their own colors and related tools.
  */
 
-import { CONSTANT } from "../constants";
 import { Image } from "astro:assets";
 import logo from "../assets/favicon.svg";
 import "../styles/global.css";


### PR DESCRIPTION
🎯 **What:** Removed the unused `CONSTANT` import from `src/layouts/ToolLayout.astro`.
💡 **Why:** The variable was imported but never utilized in the file. Removing it clears up dead code and reduces noise, improving overall maintainability.
✅ **Verification:** Verified by running a successful `npm run build` to ensure the application still compiles correctly without the import.
✨ **Result:** A cleaner file with no unused imports.

---
*PR created automatically by Jules for task [4315469477705061218](https://jules.google.com/task/4315469477705061218) started by @ragsav*