### PR TITLE
🧹 Refactor Download/Reset Buttons in Image Converters

### DIFF
--- a/src/components/DownloadResetButtons.astro
+++ b/src/components/DownloadResetButtons.astro
@@ -1,0 +1,30 @@
+---
+export interface Props {
+  downloadText?: string;
+  downloadId?: string;
+  resetText?: string;
+  resetId?: string;
+  showDownloadInitially?: boolean;
+}
+
+const {
+  downloadText = "⬇️ Download",
+  downloadId = "downloadBtn",
+  resetText = "🗑️ Reset",
+  resetId = "resetBtn",
+  showDownloadInitially = false
+} = Astro.props;
+---
+
+<button
+  id={downloadId}
+  class={`px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors ${showDownloadInitially ? '' : 'hidden'}`}
+>
+  {downloadText}
+</button>
+<button
+  id={resetId}
+  class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
+>
+  {resetText}
+</button>

--- a/src/pages/image/base64-to-image.astro
+++ b/src/pages/image/base64-to-image.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -44,8 +45,12 @@ const faqItems = [
       </div>
       <p id="imageInfo" class="text-sm text-slate-500 mb-4"></p>
       <div class="flex gap-3">
-        <button id="downloadBtn" class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700">⬇️ Download</button>
-        <button id="clearBtn" class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300">🗑️ Clear</button>
+        <DownloadResetButtons
+          downloadText="⬇️ Download"
+          resetText="🗑️ Clear"
+          resetId="clearBtn"
+          showDownloadInitially={true}
+        />
       </div>
     </div>
 

--- a/src/pages/image/bmp-to-png.astro
+++ b/src/pages/image/bmp-to-png.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -70,18 +71,7 @@ const faqItems = [
         >
           🔄 Convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download PNG
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download PNG" />
       </div>
     </div>
   </div>

--- a/src/pages/image/gif-to-png.astro
+++ b/src/pages/image/gif-to-png.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -70,18 +71,7 @@ const faqItems = [
         >
           🔄 Convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download PNG
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download PNG" />
       </div>
     </div>
   </div>

--- a/src/pages/image/heic-to-jpg.astro
+++ b/src/pages/image/heic-to-jpg.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -85,18 +86,7 @@ const faqItems = [
         >
           🔄 Re-convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors"
-        >
-          ⬇️ Download JPG
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download JPG" showDownloadInitially={true} />
       </div>
     </div>
   </div>

--- a/src/pages/image/image-compress.astro
+++ b/src/pages/image/image-compress.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -112,18 +113,7 @@ const faqItems = [
         >
           🔄 Compress
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download" />
       </div>
     </div>
   </div>

--- a/src/pages/image/image-crop.astro
+++ b/src/pages/image/image-crop.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -92,18 +93,7 @@ const faqItems = [
         >
           ✂️ Crop
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download" />
       </div>
     </div>
   </div>

--- a/src/pages/image/image-filters.astro
+++ b/src/pages/image/image-filters.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -91,8 +92,11 @@ const faqItems = [
 
       <div class="flex flex-wrap gap-3">
         <button id="resetFilters" class="px-4 py-2 font-semibold bg-amber-100 text-amber-700 rounded text-sm hover:bg-amber-200">↩ Reset Filters</button>
-        <button id="downloadBtn" class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700">⬇️ Download</button>
-        <button id="resetBtn" class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300">🗑️ Clear</button>
+        <DownloadResetButtons
+          downloadText="⬇️ Download"
+          resetText="🗑️ Clear"
+          showDownloadInitially={true}
+        />
       </div>
     </div>
   </div>

--- a/src/pages/image/image-resize.astro
+++ b/src/pages/image/image-resize.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -128,18 +129,7 @@ const faqItems = [
         >
           📐 Resize
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download" />
       </div>
     </div>
   </div>

--- a/src/pages/image/image-rotate.astro
+++ b/src/pages/image/image-rotate.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -76,8 +77,7 @@ const faqItems = [
       </div>
 
       <div class="flex flex-wrap gap-3">
-        <button id="downloadBtn" class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden">⬇️ Download</button>
-        <button id="resetBtn" class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors">🗑️ Reset</button>
+        <DownloadResetButtons downloadText="⬇️ Download" />
       </div>
     </div>
   </div>

--- a/src/pages/image/image-to-ico.astro
+++ b/src/pages/image/image-to-ico.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -99,18 +100,7 @@ const faqItems = [
         >
           🔄 Generate ICO
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download ICO
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download ICO" />
       </div>
     </div>
   </div>

--- a/src/pages/image/image-to-webp.astro
+++ b/src/pages/image/image-to-webp.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -85,18 +86,7 @@ const faqItems = [
         >
           🔄 Convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download WebP
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download WebP" />
       </div>
     </div>
   </div>

--- a/src/pages/image/jpg-to-png.astro
+++ b/src/pages/image/jpg-to-png.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -70,18 +71,7 @@ const faqItems = [
         >
           🔄 Convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download PNG
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download PNG" />
       </div>
     </div>
   </div>

--- a/src/pages/image/png-to-jpg.astro
+++ b/src/pages/image/png-to-jpg.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -92,18 +93,7 @@ const faqItems = [
         >
           🔄 Convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download JPG
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download JPG" />
       </div>
     </div>
   </div>

--- a/src/pages/image/svg-to-png.astro
+++ b/src/pages/image/svg-to-png.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -101,18 +102,7 @@ const faqItems = [
         >
           🔄 Convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download PNG
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download PNG" />
       </div>
     </div>
   </div>

--- a/src/pages/image/webp-to-png.astro
+++ b/src/pages/image/webp-to-png.astro
@@ -1,5 +1,6 @@
 ---
 import ImageToolLayout from "../../layouts/ImageToolLayout.astro";
+import DownloadResetButtons from "../../components/DownloadResetButtons.astro";
 
 const faqItems = [
   {
@@ -70,18 +71,7 @@ const faqItems = [
         >
           🔄 Convert
         </button>
-        <button
-          id="downloadBtn"
-          class="px-6 py-2 font-semibold bg-green-600 text-white rounded text-sm hover:bg-green-700 transition-colors hidden"
-        >
-          ⬇️ Download PNG
-        </button>
-        <button
-          id="resetBtn"
-          class="px-6 py-2 font-semibold bg-slate-200 text-slate-700 rounded text-sm hover:bg-slate-300 transition-colors"
-        >
-          🗑️ Reset
-        </button>
+        <DownloadResetButtons downloadText="⬇️ Download PNG" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
🎯 **What:** The duplicated HTML block for the "Download" and "Reset" buttons across 15 different image converter tools was extracted into a single, reusable component (`src/components/DownloadResetButtons.astro`).
💡 **Why:** This improves maintainability by applying the DRY (Don't Repeat Yourself) principle. Future changes to the button styles, icons, or behavior only need to be updated in one place instead of 15.
✅ **Verification:** Verified that the project builds successfully with `npm run build`. Additionally, used Playwright to test the frontend visual layout of the newly extracted component on the SVG to PNG converter page to guarantee it maintains exact styling and functionality parity.
✨ **Result:** Reduced boilerplate HTML in 15 Astro files, making the codebase cleaner and easier to maintain.

---
*PR created automatically by Jules for task [16208507262785615510](https://jules.google.com/task/16208507262785615510) started by @ragsav*