### PR TITLE
🎨 Palette: Add accessible aria-labels and tooltips to icon-only copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-06 - Missing ARIA Labels on Icon-only Buttons
+**Learning:** Found multiple icon-only copy buttons (using just the '📋' emoji) across different tool pages like slug-generator, password-generator, color-picker, etc. that lack aria-labels, making them inaccessible to screen readers.
+**Action:** When creating icon-only buttons, always ensure an `aria-label` or `title` attribute is added to provide context to assistive technologies.

--- a/src/pages/dev/color-picker.astro
+++ b/src/pages/dev/color-picker.astro
@@ -134,7 +134,7 @@ const useCases = [
             class="flex-1 px-3 py-2 border border-slate-300 rounded font-mono outline-none"
             oninput="updateFromHex()"
           />
-          <button onclick="copy('hex')" class="px-2 text-orange-600">📋</button>
+          <button onclick="copy('hex')" class="px-2 text-orange-600" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
         </div>
       </div>
       <div class="p-4 bg-white border border-slate-200 rounded">
@@ -147,7 +147,7 @@ const useCases = [
             class="flex-1 px-3 py-2 border border-slate-300 rounded font-mono text-sm outline-none"
             oninput="updateFromRgb()"
           />
-          <button onclick="copy('rgb')" class="px-2 text-orange-600">📋</button>
+          <button onclick="copy('rgb')" class="px-2 text-orange-600" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
         </div>
       </div>
       <div class="p-4 bg-white border border-slate-200 rounded">
@@ -160,7 +160,7 @@ const useCases = [
             class="flex-1 px-3 py-2 border border-slate-300 rounded font-mono text-sm outline-none"
             oninput="updateFromHsl()"
           />
-          <button onclick="copy('hsl')" class="px-2 text-orange-600">📋</button>
+          <button onclick="copy('hsl')" class="px-2 text-orange-600" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
         </div>
       </div>
     </div>

--- a/src/pages/dev/password-generator.astro
+++ b/src/pages/dev/password-generator.astro
@@ -109,7 +109,7 @@ const useCases = [
         <button
           onclick="copy()"
           class="px-4 py-2 bg-white border border-slate-300 rounded hover:border-orange-500"
-          >📋</button
+           title="Copy to clipboard" aria-label="Copy to clipboard">📋</button
         >
         <button
           onclick="generate()"

--- a/src/pages/networking/cidr-calculator.astro
+++ b/src/pages/networking/cidr-calculator.astro
@@ -269,7 +269,7 @@ const useCases = [
       blocksContainer.innerHTML = cidrBlocks.map(cidr => `
         <div class="bg-white border border-slate-200 rounded p-3 flex justify-between items-center">
           <span class="font-mono text-slate-900">${cidr}</span>
-          <button onclick="navigator.clipboard.writeText('${cidr}')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+          <button onclick="navigator.clipboard.writeText('${cidr}')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
         </div>
       `).join('');
 

--- a/src/pages/networking/ip-converter.astro
+++ b/src/pages/networking/ip-converter.astro
@@ -96,7 +96,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Decimal (Dotted)</div>
               <div id="decimalIp" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('decimalIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('decimalIp')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
         
@@ -106,7 +106,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Binary</div>
               <div id="binaryIp" class="font-mono text-lg text-slate-900 break-all">-</div>
             </div>
-            <button onclick="copyToClipboard('binaryIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('binaryIp')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
         
@@ -116,7 +116,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Hexadecimal</div>
               <div id="hexIp" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('hexIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('hexIp')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
         
@@ -126,7 +126,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Integer (32-bit)</div>
               <div id="integerIp" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('integerIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('integerIp')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
 

--- a/src/pages/networking/mac-formatter.astro
+++ b/src/pages/networking/mac-formatter.astro
@@ -92,7 +92,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Colon Separated (Unix/Linux)</div>
               <div id="colonFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('colonFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('colonFormat')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
         
@@ -102,7 +102,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Hyphen Separated (Windows)</div>
               <div id="hyphenFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('hyphenFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('hyphenFormat')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
         
@@ -112,7 +112,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Dot Separated (Cisco)</div>
               <div id="dotFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('dotFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('dotFormat')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
         
@@ -122,7 +122,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Plain (No Separator)</div>
               <div id="plainFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('plainFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('plainFormat')" class="text-slate-400 hover:text-slate-600 text-sm" title="Copy to clipboard" aria-label="Copy to clipboard">📋</button>
           </div>
         </div>
 

--- a/src/pages/text/slug-generator.astro
+++ b/src/pages/text/slug-generator.astro
@@ -149,7 +149,7 @@ const useCases = [
         <button
           onclick="copyResult()"
           class="px-4 py-2 bg-white border border-slate-300 rounded text-sm hover:border-emerald-500"
-          >📋</button
+           title="Copy to clipboard" aria-label="Copy to clipboard">📋</button
         >
       </div>
     </div>


### PR DESCRIPTION
💡 What: Added `aria-label="Copy to clipboard"` and `title="Copy to clipboard"` to all icon-only '📋' copy buttons.
🎯 Why: Without ARIA labels, these buttons lacked context for screen readers. The `title` attribute adds a helpful hover tooltip for sighted users.
♿ Accessibility: Improved screen reader support and keyboard-navigation clarity by providing semantic descriptions for previously unlabeled interactive elements.
Also documented this pattern in `.Jules/palette.md` for future context.

---
*PR created automatically by Jules for task [16831017260499197246](https://jules.google.com/task/16831017260499197246) started by @ragsav*