### PR TITLE
🎨 Palette: Add aria-label to clear search button

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -937,6 +937,7 @@ const allLiveTools = toolClusters.flatMap((c) =>
 						<button
 							id="clear-search"
 							type="button"
+							aria-label="Clear search"
 							class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors hidden"
 							onclick="clearSearch()"
 						>


### PR DESCRIPTION
💡 What: Added aria-label="Clear search" to the clear search button in the search bar.
🎯 Why: The clear search button was an icon-only button without an accessible name, making it invisible to screen readers. This improves accessibility.
♿ Accessibility: Screen reader users can now understand the purpose of the clear search button.

---
*PR created automatically by Jules for task [14111616894689907277](https://jules.google.com/task/14111616894689907277) started by @ragsav*