### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in Image Metadata Viewer

### DIFF
--- a/src/pages/image/image-metadata.astro
+++ b/src/pages/image/image-metadata.astro
@@ -72,6 +72,16 @@ const faqItems = [
     const noExif = document.getElementById('noExif');
     const resetBtn = document.getElementById('resetBtn');
 
+    function escapeHtml(str) {
+      if (!str) return '';
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     function formatSize(bytes) {
       if (bytes < 1024) return bytes + ' B';
       if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
@@ -88,11 +98,11 @@ const faqItems = [
         const img = new Image();
         img.onload = () => {
           basicInfo.innerHTML = `
-            <div><strong>Filename:</strong> ${file.name}</div>
-            <div><strong>Type:</strong> ${file.type}</div>
+            <div><strong>Filename:</strong> ${escapeHtml(file.name)}</div>
+            <div><strong>Type:</strong> ${escapeHtml(file.type)}</div>
             <div><strong>Size:</strong> ${formatSize(file.size)}</div>
             <div><strong>Dimensions:</strong> ${img.width} × ${img.height}</div>
-            <div><strong>Last Modified:</strong> ${new Date(file.lastModified).toLocaleString()}</div>
+            <div><strong>Last Modified:</strong> ${escapeHtml(new Date(file.lastModified).toLocaleString())}</div>
           `;
 
           EXIF.getData(img, function() {
@@ -107,7 +117,7 @@ const faqItems = [
                 hasData = true;
                 const row = document.createElement('tr');
                 row.className = 'border-b border-slate-100';
-                row.innerHTML = `<td class="py-2 px-4 font-medium text-slate-700">${tag}</td><td class="py-2 px-4 text-slate-600">${tags[tag]}</td>`;
+                row.innerHTML = `<td class="py-2 px-4 font-medium text-slate-700">${escapeHtml(tag)}</td><td class="py-2 px-4 text-slate-600">${escapeHtml(tags[tag])}</td>`;
                 exifTable.appendChild(row);
               }
             });
@@ -117,7 +127,7 @@ const faqItems = [
               hasData = true;
               const row = document.createElement('tr');
               row.className = 'border-b border-slate-100';
-              row.innerHTML = `<td class="py-2 px-4 font-medium text-slate-700">${tag}</td><td class="py-2 px-4 text-slate-600">${tags[tag]}</td>`;
+              row.innerHTML = `<td class="py-2 px-4 font-medium text-slate-700">${escapeHtml(tag)}</td><td class="py-2 px-4 text-slate-600">${escapeHtml(tags[tag])}</td>`;
               exifTable.appendChild(row);
             });
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS in Image Metadata Viewer

🚨 Severity: HIGH
💡 Vulnerability: The `src/pages/image/image-metadata.astro` component rendered user-controlled inputs such as the uploaded image `file.name`, `file.type`, and its internal EXIF metadata directly into the DOM using `innerHTML` template strings without proper sanitization. This introduced a persistent DOM-based Cross-Site Scripting (XSS) vulnerability.
🎯 Impact: A malicious actor could craft a specially crafted image file with malicious JavaScript payloads embedded directly in the filename or in EXIF tags (e.g., `Make`, `Model`, or custom tags). When a victim drops this image into the metadata viewer, the malicious payload would instantly execute in their browser context.
🔧 Fix: Implemented an `escapeHtml` function that safely sanitizes critical HTML entities (`&`, `<`, `>`, `"`, and `'`). Wrapped all dynamic data interpolations inside the `innerHTML` assignments with the sanitization function to prevent any unsanitized scripts from rendering as code.
✅ Verification: Ran a headless Playwright test simulating an image upload where the filename contained an XSS payload (`<img src=x onerror=alert(1)>`). Verified that the malicious tags were properly escaped and rendered safely as raw text in the Basic Info UI rather than executing the alert. Confirmed zero regressions via `pnpm build`.

---
*PR created automatically by Jules for task [8209386080420084028](https://jules.google.com/task/8209386080420084028) started by @ragsav*