### PR TITLE
🎨 Palette: Improve accessibility of icon-only copy buttons

### DIFF
--- a/src/pages/dev/color-picker.astro
+++ b/src/pages/dev/color-picker.astro
@@ -134,7 +134,7 @@ const useCases = [
             class="flex-1 px-3 py-2 border border-slate-300 rounded font-mono outline-none"
             oninput="updateFromHex()"
           />
-          <button onclick="copy('hex')" class="px-2 text-orange-600">📋</button>
+          <button onclick="copy('hex')" class="px-2 text-orange-600" aria-label="Copy hex color" title="Copy hex color">📋</button>
         </div>
       </div>
       <div class="p-4 bg-white border border-slate-200 rounded">
@@ -147,7 +147,7 @@ const useCases = [
             class="flex-1 px-3 py-2 border border-slate-300 rounded font-mono text-sm outline-none"
             oninput="updateFromRgb()"
           />
-          <button onclick="copy('rgb')" class="px-2 text-orange-600">📋</button>
+          <button onclick="copy('rgb')" class="px-2 text-orange-600" aria-label="Copy rgb color" title="Copy rgb color">📋</button>
         </div>
       </div>
       <div class="p-4 bg-white border border-slate-200 rounded">
@@ -160,7 +160,7 @@ const useCases = [
             class="flex-1 px-3 py-2 border border-slate-300 rounded font-mono text-sm outline-none"
             oninput="updateFromHsl()"
           />
-          <button onclick="copy('hsl')" class="px-2 text-orange-600">📋</button>
+          <button onclick="copy('hsl')" class="px-2 text-orange-600" aria-label="Copy hsl color" title="Copy hsl color">📋</button>
         </div>
       </div>
     </div>

--- a/src/pages/dev/password-generator.astro
+++ b/src/pages/dev/password-generator.astro
@@ -109,6 +109,8 @@ const useCases = [
         <button
           onclick="copy()"
           class="px-4 py-2 bg-white border border-slate-300 rounded hover:border-orange-500"
+          aria-label="Copy password"
+          title="Copy password"
           >📋</button
         >
         <button

--- a/src/pages/networking/ip-converter.astro
+++ b/src/pages/networking/ip-converter.astro
@@ -96,7 +96,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Decimal (Dotted)</div>
               <div id="decimalIp" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('decimalIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('decimalIp')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy IP address" title="Copy IP address">📋</button>
           </div>
         </div>
         
@@ -106,7 +106,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Binary</div>
               <div id="binaryIp" class="font-mono text-lg text-slate-900 break-all">-</div>
             </div>
-            <button onclick="copyToClipboard('binaryIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('binaryIp')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy IP address" title="Copy IP address">📋</button>
           </div>
         </div>
         
@@ -116,7 +116,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Hexadecimal</div>
               <div id="hexIp" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('hexIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('hexIp')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy IP address" title="Copy IP address">📋</button>
           </div>
         </div>
         
@@ -126,7 +126,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Integer (32-bit)</div>
               <div id="integerIp" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('integerIp')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('integerIp')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy IP address" title="Copy IP address">📋</button>
           </div>
         </div>
 

--- a/src/pages/networking/mac-formatter.astro
+++ b/src/pages/networking/mac-formatter.astro
@@ -92,7 +92,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Colon Separated (Unix/Linux)</div>
               <div id="colonFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('colonFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('colonFormat')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy MAC address" title="Copy MAC address">📋</button>
           </div>
         </div>
         
@@ -102,7 +102,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Hyphen Separated (Windows)</div>
               <div id="hyphenFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('hyphenFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('hyphenFormat')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy MAC address" title="Copy MAC address">📋</button>
           </div>
         </div>
         
@@ -112,7 +112,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Dot Separated (Cisco)</div>
               <div id="dotFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('dotFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('dotFormat')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy MAC address" title="Copy MAC address">📋</button>
           </div>
         </div>
         
@@ -122,7 +122,7 @@ const useCases = [
               <div class="text-xs text-slate-500 uppercase tracking-wide mb-1">Plain (No Separator)</div>
               <div id="plainFormat" class="font-mono text-lg text-slate-900">-</div>
             </div>
-            <button onclick="copyToClipboard('plainFormat')" class="text-slate-400 hover:text-slate-600 text-sm">📋</button>
+            <button onclick="copyToClipboard('plainFormat')" class="text-slate-400 hover:text-slate-600 text-sm" aria-label="Copy MAC address" title="Copy MAC address">📋</button>
           </div>
         </div>
 

--- a/src/pages/text/slug-generator.astro
+++ b/src/pages/text/slug-generator.astro
@@ -149,6 +149,8 @@ const useCases = [
         <button
           onclick="copyResult()"
           class="px-4 py-2 bg-white border border-slate-300 rounded text-sm hover:border-emerald-500"
+          aria-label="Copy to clipboard"
+          title="Copy to clipboard"
           >📋</button
         >
       </div>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only "copy to clipboard" buttons across various tools.
🎯 Why: Icon-only buttons without accessible names are invisible to screen readers, and lacking a title means mouse users get no context on hover. This micro-UX improvement solves both issues, making the interface more inclusive and intuitive.
📸 Before/After: Visual UI is unchanged, but screen readers now announce the button's purpose and a native browser tooltip appears on hover.
♿ Accessibility: Ensures WCAG compliance for icon-only interactive elements by providing an accessible name.

---
*PR created automatically by Jules for task [12792911625986457278](https://jules.google.com/task/12792911625986457278) started by @ragsav*