### PR TITLE
🎨 Palette: [UX improvement] Replace blocking alert with inline UI feedback on copy button

### DIFF
--- a/src/pages/text/case-converter.astro
+++ b/src/pages/text/case-converter.astro
@@ -175,8 +175,9 @@ const useCases = [
     </div>
 
     <button
+      id="copyBtn"
       onclick="copyResult()"
-      class="btn-primary px-6 py-2 font-semibold text-white rounded text-sm"
+      class="btn-primary px-6 py-2 font-semibold text-white rounded text-sm transition-colors duration-200"
       >📋 Copy Result</button
     >
   </div>
@@ -240,7 +241,22 @@ const useCases = [
       const output = document.getElementById("output");
       output.select();
       document.execCommand("copy");
-      alert("Copied to clipboard!");
+
+      const btn = document.getElementById("copyBtn");
+      if (btn.dataset.copied === "true") return; // Prevent multiple rapid clicks from breaking the text
+
+      const originalText = btn.innerHTML;
+      btn.dataset.copied = "true";
+      btn.innerHTML = "✅ Copied!";
+      btn.style.backgroundColor = "#059669"; // emerald-600
+      btn.style.borderColor = "#059669";
+
+      setTimeout(() => {
+        btn.innerHTML = originalText;
+        btn.style.backgroundColor = "";
+        btn.style.borderColor = "";
+        btn.dataset.copied = "false";
+      }, 2000);
     }
   </script>
 </TextToolLayout>


### PR DESCRIPTION
💡 What: The UX enhancement added replaces the disruptive, native browser `alert()` pop-up on the Case Converter tool's copy button with smooth, non-blocking inline visual feedback (changing the text to "✅ Copied!" and turning green for 2 seconds).

🎯 Why: The user problem it solves is that browser alerts are jarring, halt the main browser thread, and require a secondary action (clicking "OK") to dismiss. This change makes the interaction feel instantaneous and seamless, adhering to modern UX best practices for simple success confirmations.

📸 Before/After: Screenshots were captured and verified during implementation. The button now turns green with "✅ Copied!" briefly before reverting.

♿ Accessibility: Ensures the user isn't trapped in an alert dialogue, improving overall flow.

---
*PR created automatically by Jules for task [6962005053725292557](https://jules.google.com/task/6962005053725292557) started by @ragsav*